### PR TITLE
had to change one variable name, did not see new approval action edit

### DIFF
--- a/CommunityLibrary/Controllers/HomeController.cs
+++ b/CommunityLibrary/Controllers/HomeController.cs
@@ -185,7 +185,7 @@ namespace CommunityLibrary.Controllers
             Book loanedBook = _libraryDB.Books.First(x => x.Id == oldDetails.BookId);
 
             // check to see if user has loaned this book out already
-            if (loanedBook.AvailibilityStatus == false && approvalUpdate.LoanStatus)
+            if (loanedBook.AvailibilityStatus == false && newDetails.LoanStatus)
             {
                 // unable to approve loan request
                 TempData["Loaned"] = "Could not complete request: You have already loaned out this book";


### PR DESCRIPTION
just had to change a variable name - easy fix

i didn't catch the new edits on the approval action (for checking if a user had already requested a book - that feature is lost rn, my apologies. we can work it back in?)